### PR TITLE
Fix content linking bug and introduce content selectability feature

### DIFF
--- a/assets/css/stylesheet.css
+++ b/assets/css/stylesheet.css
@@ -10,6 +10,22 @@ a:hover {
   color: #90918D;
 }
 
+.unselectable {
+  -webkit-user-select: none; /* Chrome/Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* IE10+ */
+  -o-user-select: none;
+  user-select: none;
+}
+
+.section-heading {
+    border-top: 80px solid transparent;
+    margin-top: -50px;
+    -webkit-background-clip: padding-box;
+    -moz-background-clip: padding;
+    background-clip: padding-box;
+}
+
 /*-----------------------
     Main menu
 -----------------------*/

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   </head>
   <body>
     <section id="menu">
-      <div class="row unselectable">
+      <div class="row">
         <div class="col-md-6" id="logo">
           <a href="/"><img src="assets/images/rosedu_logo_transparent.png" alt="ROSEdu"/></a>
         </div>
@@ -126,7 +126,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="featured-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="featured-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -154,7 +154,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="featured-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="featured-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -183,7 +183,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="featured-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="featured-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -270,7 +270,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="book-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="book-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -298,7 +298,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="book-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="book-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -325,7 +325,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="book-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="book-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -353,7 +353,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="book-modal-content-4" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="book-modal-content-4" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -381,7 +381,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="book-modal-content-5" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="book-modal-content-5" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -409,7 +409,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade unselectable" id="book-modal-content-6" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade" id="book-modal-content-6" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   </head>
   <body>
     <section id="menu">
-      <div class="row">
+      <div class="row unselectable">
         <div class="col-md-6" id="logo">
           <a href="/"><img src="assets/images/rosedu_logo_transparent.png" alt="ROSEdu"/></a>
         </div>
@@ -42,7 +42,7 @@
       </div>
     </section>
 
-    <section class="clearfix" id="content">
+    <section class="clearfix unselectable" id="content">
 
       <!-- picture box -->
       <article class="picture-box">
@@ -59,9 +59,9 @@
       </article><!-- /picture_box -->
 
       <!-- grid -->
-      <article id="about" class="grid">
+      <article class="grid">
         <div class="col-sm-11 pull-right">
-          <h1 class="section-title">Grid</h1>
+          <h1 id="about" class="section-heading section-title">Grid</h1>
           <section class="grid row clearfix clearfix-for-2cols">
 
             <!-- grid item -->
@@ -108,10 +108,10 @@
       </article><!-- /grid -->
 
       <!-- featured -->
-      <article id="projects" class="featured">
+      <article class="featured">
         <div class="content-wrapper clearfix">
           <div class="col-sm-11 pull-right">
-            <h1 class="section-title">Featured</h1>
+            <h1 id="projects" class="section-heading section-title">Featured</h1>
             <!-- feature columns -->
             <section class="feature-columns row clearfix">
 
@@ -126,7 +126,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="featured-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="featured-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -154,7 +154,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="featured-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="featured-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -183,7 +183,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="featured-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="featured-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -207,10 +207,10 @@
       </article><!-- /featured -->
 
       <!-- album -->
-      <article id="sponsors" class="album">
+      <article class="album">
         <div class="content-wrapper clearfix">
           <div class="col-sm-11 pull-right">
-            <h1 class="section-title">Album</h1>
+            <h1 id="sponsors" class="section-heading section-title">Album</h1>
             <!-- album columns -->
             <section class="feature-columns row clearfix">
 
@@ -253,10 +253,10 @@
       </article><!-- /album -->
 
       <!-- book -->
-      <article id="participants" class="book">
+      <article class="book">
         <div class="content-wrapper clearfix">
           <div class="col-sm-11 pull-right">
-            <h1 class="section-title">Book</h1>
+            <h1 id="participants" class="section-heading section-title">Book</h1>
             <!-- book columns -->
             <section class="feature-columns row clearfix">
 
@@ -270,7 +270,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="book-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="book-modal-content-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -298,7 +298,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="book-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="book-modal-content-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -325,7 +325,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="book-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="book-modal-content-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -353,7 +353,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="book-modal-content-4" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="book-modal-content-4" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -381,7 +381,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="book-modal-content-5" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="book-modal-content-5" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
@@ -409,7 +409,7 @@
                   </div>
                 </a><!-- /thumbnail -->
 
-                <div class="modal fade" id="book-modal-content-6" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal fade unselectable" id="book-modal-content-6" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>


### PR DESCRIPTION
As a user would be kind of frustrating to have the permission to select content from a website.
This patch fixes the vulnerability, so the user is not allowed to do any text or image selection even in modals.

For the content section linking bug, I found a way to fix it using a border, negative margins, and background-clip and it looks pretty nice. In addition, it seems that is supported by all browsers: Firefox 1.0+, Opera 10.5+, Safari 3+, Chrome.
